### PR TITLE
Add edgeCloudFootprint to EdgeCloudZone response schema

### DIFF
--- a/code/API_definitions/optimal-edge-discovery.yaml
+++ b/code/API_definitions/optimal-edge-discovery.yaml
@@ -114,7 +114,15 @@ info:
         "edgeCloudZoneName": "Example Zone Name",
         "edgeCloudProvider": "Example Zone Provider",
         "edgeCloudRegion": "us-west-1",
-        "status": "active"
+        "status": "active",
+        "edgeCloudFootprint": {
+          "areaType": "CIRCLE",
+          "center": {
+            "latitude": 39.95,
+            "longitude": -105.16
+          },
+          "radius": 50000
+        }
       }
     ],
     "applicationProfileId": "2fa85f64-5717-4562-b3fc-2c963f66afa0",
@@ -131,6 +139,13 @@ info:
     * `edgeCloudRegion` is the region of the closest Edge Cloud Zone to
     the user device.
     * `status` is the status of the Edge Cloud Zone (default is 'unknown').
+    * `edgeCloudFootprint` is an optional field representing the geographic
+    coverage area that this edge zone is optimized to serve. It can be
+    specified as either a Circle (center point with radius in meters) or a
+    Polygon (list of boundary points). This field aids in visualization and
+    data governance use cases. Note that this represents the network-optimized
+    service area where devices are likely routed to this zone, not physical
+    proximity to infrastructure.
     * `edgeCloudZones` is an array of Edge Cloud Zones that match the query
     parameters. The array will contain at least one Edge Cloud Zone, and
     may contain multiple Edge Cloud Zones if there are multiple zones that
@@ -393,6 +408,17 @@ components:
             - inactive
             - unknown
           default: unknown
+        edgeCloudFootprint:
+          description: |
+            The approximate geographic area that this edge cloud zone is intended to
+            serve. The footprint represents a logical service region where devices are
+            likely to be routed to this zone based on network topology and operator
+            policies, rather than the physical location of underlying infrastructure.
+            This information is provided for coarse selection, visualization in
+            orchestration or management portals, and to support region-based
+            considerations such as data residency.
+          allOf:
+            - $ref: "#/components/schemas/Area"
       required:
         - edgeCloudZoneId
         - edgeCloudZoneName
@@ -585,6 +611,96 @@ components:
       type: string
       format: ipv6
       example: 2001:db8:85a3:8d3:1319:8a2e:370:7344
+
+    Area:
+      description: Base schema for all areas
+      type: object
+      properties:
+        areaType:
+          $ref: "#/components/schemas/AreaType"
+      required:
+        - areaType
+      discriminator:
+        propertyName: areaType
+        mapping:
+          CIRCLE: "#/components/schemas/Circle"
+          POLYGON: "#/components/schemas/Polygon"
+
+    AreaType:
+      type: string
+      description: |
+        Type of this area.
+        CIRCLE - The area is defined as a circle.
+        POLYGON - The area is defined as a polygon.
+      enum:
+        - CIRCLE
+        - POLYGON
+
+    Circle:
+      description: Circular area
+      allOf:
+        - $ref: "#/components/schemas/Area"
+        - type: object
+          required:
+            - center
+            - radius
+          properties:
+            center:
+              $ref: "#/components/schemas/Point"
+            radius:
+              type: number
+              description: Distance from the center in meters
+              minimum: 1
+
+    Polygon:
+      description: |
+        Polygonal area. The Polygon should be a simple polygon,
+        i.e. should not intersect itself.
+      allOf:
+        - $ref: "#/components/schemas/Area"
+        - type: object
+          required:
+            - boundary
+          properties:
+            boundary:
+              $ref: "#/components/schemas/PointList"
+
+    PointList:
+      description: List of points defining a polygon
+      type: array
+      items:
+        $ref: "#/components/schemas/Point"
+      minItems: 3
+      maxItems: 15
+
+    Point:
+      type: object
+      description: Coordinates (latitude, longitude) defining a location in a map
+      required:
+        - latitude
+        - longitude
+      properties:
+        latitude:
+          $ref: "#/components/schemas/Latitude"
+        longitude:
+          $ref: "#/components/schemas/Longitude"
+      example:
+        latitude: 50.735851
+        longitude: 7.10066
+
+    Latitude:
+      description: Latitude component of a location
+      type: number
+      format: double
+      minimum: -90
+      maximum: 90
+
+    Longitude:
+      description: Longitude component of location
+      type: number
+      format: double
+      minimum: -180
+      maximum: 180
 
   ######################################################
   #  RESPONSES


### PR DESCRIPTION

#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

This PR introduces an optional `edgeCloudFootprint` field to the `EdgeCloudZone` schema, enabling API consumers to understand the geographic coverage area that an edge cloud zone is intended to serve.

**Key points:**

- **Not physical proximity**: The footprint represents a *logical service region* where devices are likely routed based on network topology and operator policies—not the physical location of underlying infrastructure. As discussed in the API working group, "what the API gives you is not just based on location proximity to a UE. It's actually based on how the data is getting routed."

- **Use cases**:
  1. **Visualization**: Display edge zones on maps in orchestration/management portals
  2. **Data governance**: Identify territorial boundaries for data residency requirements (e.g., EU regulations requiring data to remain within specific regions or even counties)
  3. **Coarse zone selection**: Programmatically filter zones based on coverage overlap with target service areas

- **Privacy-preserving**: The footprint describes the service area, not the physical infrastructure location

**Schema additions:**
- `edgeCloudFootprint` field on `EdgeCloudZone` (optional)
- `Area`, `AreaType`, `Circle`, `Polygon`, `PointList`, `Point`, `Latitude`, `Longitude` schemas copied from CAMARA_common.yaml patterns

#### Which issue(s) this PR fixes:

Fixes #25

#### Special notes for reviewers:

1. The Area/Circle/Polygon schemas are copied directly into this spec rather than using `$ref` to CAMARA_common.yaml. A separate issue will be filed to address consolidating these common types via external reference once approved.

2. The `edgeCloudFootprint` description emphasizes that this represents the network-optimized service area, not physical proximity. This distinction was highlighted in working group discussions—a device entering a zone's geographic footprint does not guarantee that zone is optimal for that device, as routing depends on network topology.

3. The field is optional to maintain backward compatibility.

#### Changelog input

```
release-note
Add optional edgeCloudFootprint field to EdgeCloudZone response schema, enabling geographic coverage visualization and data residency use cases
```

#### Additional documentation

```
docs
Updated API description with edgeCloudFootprint field documentation and example response showing Circle footprint usage
```
