### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,7 +6,7 @@
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
 # Replace the following line with "* @codeowner1 @codeowner2 @codeowner3" with the individual codeowner user names (the CODEOWNER file is the source of truth for the sub project codeowner team)
-* @gunjald @Kevsy @crissancas @FabrizioMoggio @seralogar @gainsley @JoseMConde @maheshc01
+* @gunjald @Kevsy @FabrizioMoggio @seralogar @gainsley @JoseMConde @maheshc01
 
 # Owners of the CODEOWNER and Maintainer.md files are the admins of CAMARA (to allow them to keep the teams within the CAMARA organization in sync in case of changes)
 /CODEOWNERS @camaraproject/admins


### PR DESCRIPTION
Remove Cristina as a codeowner.

#### What type of PR is this?


* cleanup



#### What this PR does / why we need it:

To remove Cristina as a codeowner.


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
