### PR TITLE
Add pre-deployment edge cloud zone viability discovery

### DIFF
--- a/code/API_definitions/optimal-edge-discovery.yaml
+++ b/code/API_definitions/optimal-edge-discovery.yaml
@@ -617,15 +617,6 @@ components:
             or unknown results. This field should be omitted for
             straightforward `VIABLE` results.
           type: string
-        servedTargetAreas:
-          description: |
-            Requested target areas that can be served by this candidate edge
-            cloud zone. This can include other target areas from the same
-            request in addition to the `targetArea` of the current per-area
-            result.
-          type: array
-          items:
-            $ref: "#/components/schemas/TargetArea"
         networkOperatorPlanningInfo:
           $ref: "#/components/schemas/NetworkOperatorPlanningInfo"
         estimatedMetrics:
@@ -715,19 +706,113 @@ components:
     TargetArea:
       description: |
         Target demand or service area for pre-deployment planning.
+        The area is expressed as explicit geographic geometry to avoid relying on
+        provider-specific area identifiers.
       type: object
       required:
-        - areaId
+        - area
       properties:
-        areaId:
-          $ref: "#/components/schemas/AreaId"
+        area:
+          $ref: "#/components/schemas/Area"
 
-    AreaId:
-      description: Identifier of a target or supported area.
+    Area:
+      type: object
+      description: |
+        Geographic area used for pre-deployment planning. This follows the
+        CAMARA pattern used by location/region APIs, where an area is expressed
+        using explicit geometry.
+      required:
+        - areaType
+      properties:
+        areaType:
+          $ref: "#/components/schemas/AreaType"
+      discriminator:
+        propertyName: areaType
+        mapping:
+          CIRCLE: "#/components/schemas/Circle"
+          POLYGON: "#/components/schemas/Polygon"
+
+    AreaType:
       type: string
-      minLength: 1
-      maxLength: 128
-      example: "patras"
+      description: |
+        Type of geographic area.
+        CIRCLE - Area defined by a center point and radius.
+        POLYGON - Area defined by a polygon boundary.
+      enum:
+        - CIRCLE
+        - POLYGON
+
+    Circle:
+      description: Circular geographic area.
+      allOf:
+        - $ref: "#/components/schemas/Area"
+        - type: object
+          required:
+            - center
+            - radius
+          properties:
+            center:
+              $ref: "#/components/schemas/Point"
+            radius:
+              type: number
+              description: Radius in meters from the center point.
+              minimum: 1
+          example:
+            areaType: CIRCLE
+            center:
+              latitude: 38.2466
+              longitude: 21.7346
+            radius: 5000
+
+    Polygon:
+      description: Polygon geographic area.
+      allOf:
+        - $ref: "#/components/schemas/Area"
+        - type: object
+          required:
+            - boundary
+          properties:
+            boundary:
+              $ref: "#/components/schemas/PointList"
+
+    PointList:
+      type: array
+      description: List of points defining a polygon boundary.
+      minItems: 3
+      maxItems: 15
+      items:
+        $ref: "#/components/schemas/Point"
+
+    Point:
+      type: object
+      description: Coordinates defining a location.
+      required:
+        - latitude
+        - longitude
+      properties:
+        latitude:
+          $ref: "#/components/schemas/Latitude"
+        longitude:
+          $ref: "#/components/schemas/Longitude"
+      example:
+        latitude: 38.2466
+        longitude: 21.7346
+
+    Latitude:
+      description: Latitude component of a location.
+      type: number
+      format: double
+      minimum: -90
+      maximum: 90
+      example: 38.2466
+
+    Longitude:
+      description: Longitude component of a location.
+      type: number
+      format: double
+      minimum: -180
+      maximum: 180
+      example: 21.7346
 
     EstimatedMetrics:
       description: Planning metrics estimated for the candidate edge cloud zone.
@@ -1124,8 +1209,18 @@ components:
         before deployment using the optimal edge discovery operation.
       value:
         targetAreas:
-          - areaId: "patras"
-          - areaId: "athens"
+          - area:
+              areaType: CIRCLE
+              center:
+                latitude: 38.2466
+                longitude: 21.7346
+              radius: 5000
+          - area:
+              areaType: CIRCLE
+              center:
+                latitude: 37.9838
+                longitude: 23.7275
+              radius: 10000
         applicationProfileId: "2fa85f64-5717-4562-b3fc-2c963f66afa0"
         edgeCloudZoneCriteria:
           edgeCloudRegion: "gr-west-1"
@@ -1144,7 +1239,12 @@ components:
         planning results.
       value:
         targetAreas:
-          - areaId: "patras"
+          - area:
+              areaType: CIRCLE
+              center:
+                latitude: 38.2466
+                longitude: 21.7346
+              radius: 5000
         applicationProfileId: "2fa85f64-5717-4562-b3fc-2c963f66afa0"
         edgeCloudZoneCriteria:
           edgeCloudRegion: "gr-west-1"
@@ -1164,7 +1264,12 @@ components:
             edgeCloudZoneStatus: active
         areaResults:
           - targetArea:
-              areaId: "patras"
+              area:
+                areaType: CIRCLE
+                center:
+                  latitude: 38.2466
+                  longitude: 21.7346
+                radius: 5000
             edgeCloudZoneViabilities:
               - edgeCloudZone:
                   edgeCloudZoneId: "4f7b5555-6457-4890-9d4e-1dc79f44ab66"
@@ -1173,10 +1278,6 @@ components:
                   edgeCloudRegion: "gr-west-1"
                   edgeCloudZoneStatus: active
                 viability: VIABLE
-                servedTargetAreas:
-                  - areaId: "patras"
-                  - areaId: "ioannina"
-                  - areaId: "larissa"
                 networkOperatorPlanningInfo:
                   planningClasses:
                     - PREMIUM
@@ -1195,8 +1296,6 @@ components:
                   conditionType: SERVICE_ACTIVATION_REQUIRED
                   expectedActivationDelay: "PT1H"
                   description: "Service activation is required before deployment."
-                servedTargetAreas:
-                  - areaId: "patras"
                 networkOperatorPlanningInfo:
                   planningClasses:
                     - STANDARD
@@ -1205,7 +1304,12 @@ components:
                     p50LatencyMs: 11
                     p95LatencyMs: 18
           - targetArea:
-              areaId: "athens"
+              area:
+                areaType: CIRCLE
+                center:
+                  latitude: 37.9838
+                  longitude: 23.7275
+                radius: 10000
             edgeCloudZoneViabilities: []
 
     PreDeploymentPlanningWithNonViableResponse:
@@ -1216,7 +1320,12 @@ components:
         edgeCloudZones: []
         areaResults:
           - targetArea:
-              areaId: "patras"
+              area:
+                areaType: CIRCLE
+                center:
+                  latitude: 38.2466
+                  longitude: 21.7346
+                radius: 5000
             edgeCloudZoneViabilities:
               - edgeCloudZone:
                   edgeCloudZoneId: "dc10c463-d604-4f2f-a002-c1199de12d6f"
@@ -1226,7 +1335,6 @@ components:
                   edgeCloudZoneStatus: active
                 viability: NOT_VIABLE
                 viabilityReason: "The requested application profile requirements cannot be met for this target area."
-                servedTargetAreas: []
                 estimatedMetrics:
                   latencyEstimate:
                     p50LatencyMs: 35

--- a/code/API_definitions/optimal-edge-discovery.yaml
+++ b/code/API_definitions/optimal-edge-discovery.yaml
@@ -45,7 +45,7 @@ info:
         target areas and an application profile before any active device or
         user session exists.
 
-    Pre-deployment discovery is planning-oriented. It returns planning
+    The pre-deployment operation is planning-oriented. It returns planning
     estimates only and does not provide runtime steering, traffic-routing
     instructions, or guarantees about future network performance. The API
     intentionally exposes only public planning abstractions and does not expose
@@ -58,14 +58,14 @@ info:
 
     # Identifying the device
 
-    For device-specific discovery, the API returns the closest Edge Cloud Zone
-    to a given device, so that device needs to be identifiable by the network.
-    This can be achieved by passing one or more device identifiers in the
-    request.
+    The API returns the closest Edge Cloud Zone to a given device, so that
+    device needs to be identifiable by the network. This can be achieved either
+    by passing one or more device identifiers in the request, or, from the
+    three-legged access token where implemented by the operator.
 
     ## Passing device identifier(s) in the request
-    At least one of the following device identifiers must be provided for
-    device-specific discovery:
+    At least one of the following device identifiers must be provided, unless
+    using a 3-legged access toekn (see next section):
      - Phone number (i.e. MSISDN)
      - Network Access Identifier assigned by the mobile network operator for the device
      - IPv6 address
@@ -82,6 +82,22 @@ info:
     CAMARA does not currently allow its use. After the CAMARA meta-release work
     is concluded and the relevant issues are resolved, its use will need to be
     explicitly documented in the guidelines.
+
+
+    ## Identifying the device from the access token
+
+    This API requires the API consumer to identify a device as the subject of
+    the API as follows:
+
+    - When the API is invoked using a two-legged access token, the subject will be
+    identified from the optional `device` object, which therefore MUST be provided.
+    - When a three-legged access token is used however, this optional identifier
+    MUST NOT be provided, as the subject will be uniquely identified from the access
+    token.
+
+    This approach simplifies API usage for API consumers using a three-legged access
+    token to invoke the API by relying on the information that is associated with the
+    access token and was identified during the authentication process.
 
     ## Error handling:
 
@@ -143,6 +159,9 @@ info:
       - `ipv6Address`: The public IPv6 address of the device.
     The response will contain only one of these identifiers, depending on
     which identifier was used to identify the device in the request.
+    If the device was identified from the access token, the `device` object
+    will not be present in the response, and the `applicationProfileId` will
+    be the only field returned.
 
     For pre-deployment planning requests, the API consumer provides
     `targetAreas` instead of a device identifier. The response can include
@@ -216,7 +235,7 @@ externalDocs:
 #                                     Servers                              #
 ############################################################################
 servers:
-  - url: "{apiRoot}/optimal-edge-discovery/v0.1.0"
+  - url: "{apiRoot}/optimal-edge-discovery/vwip"
     variables:
       apiRoot:
         default: https://localhost:9091
@@ -232,9 +251,11 @@ tags:
       Get all Region IDs and Names for edge cloud zones
   - name: Discovery
     description: |
-      Discover the regions and zones in the edge cloud application and find
-      optimal edge cloud zones for deployed applications or pre-deployment
-      planning.
+      Discover the regions and zones in the edge cloud
+      application, find optimal edge cloud zones for
+      your deployed applications, optimal Application
+      Endpoints for your clients to connect to, and viable
+      edge cloud zone candidates for pre-deployment planning.
 ############################################################################
 #                                     Paths                                #
 ############################################################################
@@ -331,17 +352,14 @@ paths:
           $ref: "#/components/responses/Generic429"
       tags:
         - Discovery
-      summary: Discover optimal edge cloud zones
+      summary: Discover optimal edge cloud zones for deployed applications
       description: |
-        Returns a list of optimal edge cloud zones where an application can be
-        deployed or registered. The request must provide either `device` for
-        device-specific discovery, or `targetAreas` for pre-deployment planning
-        before any active device or user session exists.
-
-        When `targetAreas` are provided, returned viability and metric values
-        are planning indicators only. They do not represent runtime steering,
-        routing, topology, UPF, DNN, S-NSSAI, operator-internal details,
-        reservations, SLAs, or future performance guarantees.
+        Returns a list of optimal edge cloud zones where you can register your
+        deployed application. You can choose to search with a combination of
+        Application Profile and device information, or with target areas for
+        pre-deployment planning. Planning results are estimates only and do not
+        represent runtime steering, routing, topology, reservations, SLAs, or
+        future performance guarantees.
 
 components:
   securitySchemes:

--- a/code/API_definitions/optimal-edge-discovery.yaml
+++ b/code/API_definitions/optimal-edge-discovery.yaml
@@ -250,7 +250,8 @@ tags:
     description: |
       Discover the regions and zones in the edge cloud
       application, find optimal edge cloud zones for
-      your deployed applications, and retrieve viable
+      your deployed applications, optimal Application
+      Endpoints for your clients to connect to, and viable
       edge cloud zone candidates for pre-deployment planning.
 ############################################################################
 #                                     Paths                                #

--- a/code/API_definitions/optimal-edge-discovery.yaml
+++ b/code/API_definitions/optimal-edge-discovery.yaml
@@ -716,16 +716,11 @@ components:
       description: |
         Target demand or service area for pre-deployment planning.
       type: object
+      required:
+        - areaId
       properties:
         areaId:
           $ref: "#/components/schemas/AreaId"
-        area:
-          $ref: "#/components/schemas/Area"
-      anyOf:
-        - required:
-            - areaId
-        - required:
-            - area
 
     AreaId:
       description: Identifier of a target or supported area.
@@ -733,26 +728,6 @@ components:
       minLength: 1
       maxLength: 128
       example: "patras"
-
-    # TODO: Replace this local placeholder with a reference to the CAMARA
-    # Commonalities Area schema once the common schema file is imported into
-    # this repository.
-    Area:
-      description: |
-        Geographic area used for pre-deployment planning. This placeholder
-        should be replaced by the CAMARA Commonalities `Area` schema.
-      type: object
-      properties:
-        areaId:
-          $ref: "#/components/schemas/AreaId"
-        name:
-          type: string
-          example: "Patras Metro"
-        countryCode:
-          type: string
-          pattern: "^[A-Z]{2}$"
-          example: "GR"
-      minProperties: 1
 
     EstimatedMetrics:
       description: Planning metrics estimated for the candidate edge cloud zone.

--- a/code/API_definitions/optimal-edge-discovery.yaml
+++ b/code/API_definitions/optimal-edge-discovery.yaml
@@ -41,7 +41,7 @@ info:
         `/retrieve-optimal-edge-cloud-zones` API.
 
     - **Pre-deployment Edge Cloud Zone Viability Discovery**: To evaluate which
-        edge cloud zones are viable candidates for target areas and an
+        edge cloud zones known to the API Publisher are viable candidates for target areas and an
         application profile before any active device or user session exists.
         This can be achieved using the
         `/retrieve-viable-edge-cloud-zones` API.

--- a/code/API_definitions/optimal-edge-discovery.yaml
+++ b/code/API_definitions/optimal-edge-discovery.yaml
@@ -40,6 +40,19 @@ info:
         region. This can be achieved using the
         `/retrieve-optimal-edge-cloud-zones` API.
 
+    - **Pre-deployment Edge Cloud Zone Viability Discovery**: To evaluate which
+        edge cloud zones are viable candidates for target areas and an
+        application profile before any active device or user session exists.
+        This can be achieved using the
+        `/retrieve-viable-edge-cloud-zones` API.
+
+    The pre-deployment operation is planning-oriented. It returns planning
+    estimates only and does not provide runtime steering, traffic-routing
+    instructions, or guarantees about future network performance. The API
+    intentionally exposes only public planning abstractions and does not expose
+    UPF, DNN, S-NSSAI, routing policy, topology, or other internal operator
+    details.
+
     To call these endpoints, the API consumer must first obtain a valid OAuth2 token
     from the token endpoint, and pass it as an `Authorization` header in the API
     request.
@@ -237,8 +250,8 @@ tags:
     description: |
       Discover the regions and zones in the edge cloud
       application, find optimal edge cloud zones for
-      your deployed applications, and optimal
-      Application Endpoints for your clients to connect to.
+      your deployed applications, and retrieve viable
+      edge cloud zone candidates for pre-deployment planning.
 ############################################################################
 #                                     Paths                                #
 ############################################################################
@@ -333,6 +346,63 @@ paths:
          register your deployed application. You can choose to search without
          passing any of the inputs parameters or a combination of Application
          Profile and device information.
+  /retrieve-viable-edge-cloud-zones:
+    post:
+      operationId: retrieveViableEdgeCloudZones
+      security:
+        - openId:
+            - "optimal-edge-discovery:viable-edge-zones:read"
+      parameters:
+        - $ref: "#/components/parameters/x-correlator"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PreDeploymentEdgeDiscoveryInfo"
+            examples:
+              Retrieve Viable Edge Cloud Zones:
+                $ref: "#/components/examples/RetrieveViableEdgeCloudZonesRequest"
+      responses:
+        "200":
+          description: |
+            Returns edge cloud zone viability results for pre-deployment
+            planning. Results are estimates and are not runtime performance
+            guarantees.
+          headers:
+            x-correlator:
+              $ref: "#/components/headers/x-correlator"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PreDeploymentEdgeDiscoveryResponse"
+              examples:
+                Viable Edge Cloud Zones:
+                  $ref: "#/components/examples/RetrieveViableEdgeCloudZonesResponse"
+        "400":
+          $ref: "#/components/responses/Generic400"
+        "401":
+          $ref: "#/components/responses/Generic401"
+        "403":
+          $ref: "#/components/responses/Generic403"
+        "404":
+          $ref: "#/components/responses/Generic404"
+        "422":
+          $ref: "#/components/responses/Generic422"
+        "429":
+          $ref: "#/components/responses/Generic429"
+      tags:
+        - Discovery
+      summary: Retrieve viable edge cloud zones for pre-deployment planning
+      description: |
+        Evaluates which edge cloud zones are viable for target geographic
+        areas, an application profile, and optional planning criteria before
+        deployment.
+
+        The operation does not require an active device and does not return
+        runtime steering, routing, topology, UPF, DNN, S-NSSAI, or other
+        operator-internal details. Estimated metrics are planning indicators
+        only and must not be interpreted as runtime guarantees.
 
 components:
   securitySchemes:
@@ -386,13 +456,7 @@ components:
         edgeCloudRegion:
           $ref: "#/components/schemas/EdgeCloudRegion"
         status:
-          description: Status of the Edge cloud zone (default is 'unknown')
-          type: string
-          enum:
-            - active
-            - inactive
-            - unknown
-          default: unknown
+          $ref: "#/components/schemas/EdgeCloudZoneStatus"
       required:
         - edgeCloudZoneId
         - edgeCloudZoneName
@@ -426,6 +490,15 @@ components:
         The common name of the closest Edge Cloud Zone to the user device.
       type: string
       example: "us-west-1"
+
+    EdgeCloudZoneStatus:
+      description: Status of the Edge cloud zone (default is 'unknown')
+      type: string
+      enum:
+        - active
+        - inactive
+        - unknown
+      default: unknown
 
     ErrorInfo:
       type: object
@@ -463,6 +536,245 @@ components:
       required:
         - applicationProfileId
 
+    PreDeploymentEdgeDiscoveryInfo:
+      description: |
+        Request resource to retrieve viable edge cloud zones for
+        pre-deployment planning. The request is not associated with an active
+        device or session. Application network and compute requirements are
+        referenced through `applicationProfileId`; this request only describes
+        target areas and optional planning criteria.
+      type: object
+      required:
+        - targetAreas
+        - applicationProfileId
+      properties:
+        targetAreas:
+          description: |
+            Target demand or service areas for which edge cloud zone viability
+            is evaluated.
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/TargetArea"
+        applicationProfileId:
+          $ref: "#/components/schemas/ApplicationProfileId"
+        edgeCloudZoneCriteria:
+          $ref: "#/components/schemas/EdgeCloudZoneCriteria"
+        networkOperatorCriteria:
+          $ref: "#/components/schemas/NetworkOperatorCriteria"
+        maxResults:
+          description: Maximum number of viability results to return per
+            target area.
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 10
+        includeNonViableCandidates:
+          description: |
+            Indicates whether results with `NOT_VIABLE` or `UNKNOWN` viability
+            can be included in the response. When false, only `VIABLE` and
+            `PARTIALLY_VIABLE` results are returned.
+          type: boolean
+          default: false
+
+    PreDeploymentEdgeDiscoveryResponse:
+      description: |
+        Response resource containing edge cloud zone viability results for
+        pre-deployment planning. Results are planning estimates and do not
+        represent runtime availability guarantees, reservations, or SLAs.
+      type: object
+      required:
+        - applicationProfileId
+        - areaResults
+        - validUntil
+      properties:
+        applicationProfileId:
+          $ref: "#/components/schemas/ApplicationProfileId"
+        areaResults:
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/AreaEdgeCloudZoneViabilityResult"
+        validUntil:
+          description: |
+            Timestamp until which the API provider considers this planning
+            response fresh enough for pre-deployment decision making. This is
+            not a runtime availability guarantee, reservation, or SLA.
+          type: string
+          format: date-time
+
+    AreaEdgeCloudZoneViabilityResult:
+      description: Viability results for a requested target area.
+      type: object
+      required:
+        - targetArea
+        - edgeCloudZoneViabilities
+      properties:
+        targetArea:
+          $ref: "#/components/schemas/TargetArea"
+        edgeCloudZoneViabilities:
+          type: array
+          items:
+            $ref: "#/components/schemas/EdgeCloudZoneViability"
+
+    EdgeCloudZoneViability:
+      description: |
+        Planning result for one candidate edge cloud zone. This result is not
+        a runtime routing decision and does not expose operator-internal
+        topology or policy.
+      type: object
+      required:
+        - edgeCloudZone
+        - viability
+      properties:
+        edgeCloudZone:
+          $ref: "#/components/schemas/EdgeCloudZone"
+        viability:
+          type: string
+          description: |
+            Planning viability of the edge cloud zone for the requested target
+            area and application profile.
+          enum:
+            - VIABLE
+            - PARTIALLY_VIABLE
+            - NOT_VIABLE
+            - UNKNOWN
+        viabilityReason:
+          description: |
+            Optional human-readable explanation for partial, non-viable, or
+            unknown results. This field should be omitted for straightforward
+            `VIABLE` results.
+          type: string
+        supportedAreas:
+          description: Areas supported by this edge cloud zone for planning.
+          type: array
+          items:
+            $ref: "#/components/schemas/TargetArea"
+        networkOperatorCommercialInfo:
+          $ref: "#/components/schemas/NetworkOperatorCommercialInfo"
+        estimatedMetrics:
+          $ref: "#/components/schemas/EstimatedMetrics"
+
+    EdgeCloudZoneCriteria:
+      description: Optional edge-cloud-zone candidate criteria.
+      type: object
+      properties:
+        edgeCloudRegion:
+          $ref: "#/components/schemas/EdgeCloudRegion"
+        edgeCloudProviders:
+          description: |
+            Edge cloud providers to include as candidate providers. This is a
+            provider-level planning filter and is not a network routing policy.
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/EdgeCloudProvider"
+      minProperties: 1
+
+    NetworkOperatorCriteria:
+      description: |
+        Optional broad network-operator-side planning criteria. This object
+        must not contain routing, topology, UPF, DNN, S-NSSAI, or policy
+        details.
+      type: object
+      properties:
+        pricingTiers:
+          description: |
+            Broad network-operator commercial planning classes to consider.
+            These values are not price quotes and do not represent edge cloud
+            provider pricing.
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/PricingTier"
+      minProperties: 1
+
+    NetworkOperatorCommercialInfo:
+      description: |
+        Broad network-operator-side commercial planning information associated
+        with a candidate edge cloud zone. This is not an edge cloud provider
+        price and is not a binding quote.
+      type: object
+      properties:
+        pricingTiers:
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/PricingTier"
+
+    PricingTier:
+      description: Broad network-operator commercial planning class.
+      type: string
+      enum:
+        - STANDARD
+        - PREMIUM
+        - ENTERPRISE
+        - UNKNOWN
+
+    TargetArea:
+      description: |
+        Target demand or service area for pre-deployment planning.
+      type: object
+      properties:
+        areaId:
+          $ref: "#/components/schemas/AreaId"
+        area:
+          $ref: "#/components/schemas/Area"
+      anyOf:
+        - required:
+            - areaId
+        - required:
+            - area
+
+    AreaId:
+      description: Identifier of a target or supported area.
+      type: string
+      minLength: 1
+      maxLength: 128
+      example: "patras"
+
+    # TODO: Replace this local placeholder with a reference to the CAMARA
+    # Commonalities Area schema once the common schema file is imported into
+    # this repository.
+    Area:
+      description: |
+        Geographic area used for pre-deployment planning. This placeholder
+        should be replaced by the CAMARA Commonalities `Area` schema.
+      type: object
+      properties:
+        areaId:
+          $ref: "#/components/schemas/AreaId"
+        name:
+          type: string
+          example: "Patras Metro"
+        countryCode:
+          type: string
+          pattern: "^[A-Z]{2}$"
+          example: "GR"
+      minProperties: 1
+
+    EstimatedMetrics:
+      description: Planning metrics estimated for the candidate edge cloud zone.
+      type: object
+      properties:
+        latencyEstimate:
+          $ref: "#/components/schemas/LatencyEstimate"
+      minProperties: 1
+
+    LatencyEstimate:
+      description: |
+        Estimated latency values for pre-deployment planning. These values are
+        not runtime guarantees.
+      type: object
+      properties:
+        p50LatencyMs:
+          type: integer
+          minimum: 0
+          example: 8
+        p95LatencyMs:
+          type: integer
+          minimum: 0
+          example: 14
 
     DeviceResponse:
       description: |
@@ -835,3 +1147,54 @@ components:
             publicAddress: "84.125.93.10"
             publicPort: 59765
           networkAccessIdentifier: "123456789@domain.com"
+
+    RetrieveViableEdgeCloudZonesRequest:
+      description: |
+        Retrieve viable edge cloud zones for a cloud gaming application profile
+        before deployment.
+      value:
+        targetAreas:
+          - areaId: "patras"
+          - areaId: "athens"
+        applicationProfileId: "2fa85f64-5717-4562-b3fc-2c963f66afa0"
+        edgeCloudZoneCriteria:
+          edgeCloudRegion: "gr-west-1"
+          edgeCloudProviders:
+            - "EdgeCo Neutral Host"
+        networkOperatorCriteria:
+          pricingTiers:
+            - STANDARD
+            - PREMIUM
+        maxResults: 4
+        includeNonViableCandidates: false
+
+    RetrieveViableEdgeCloudZonesResponse:
+      description: Viable edge cloud zone planning response.
+      value:
+        applicationProfileId: "2fa85f64-5717-4562-b3fc-2c963f66afa0"
+        validUntil: "2026-05-19T12:15:00Z"
+        areaResults:
+          - targetArea:
+              areaId: "patras"
+            edgeCloudZoneViabilities:
+              - edgeCloudZone:
+                  edgeCloudZoneId: "4f7b5555-6457-4890-9d4e-1dc79f44ab66"
+                  edgeCloudZoneName: "GR West Zone A"
+                  edgeCloudProvider: "EdgeCo Neutral Host"
+                  edgeCloudRegion: "gr-west-1"
+                  status: active
+                viability: VIABLE
+                supportedAreas:
+                  - areaId: "patras"
+                  - areaId: "ioannina"
+                  - areaId: "larissa"
+                networkOperatorCommercialInfo:
+                  pricingTiers:
+                    - PREMIUM
+                estimatedMetrics:
+                  latencyEstimate:
+                    p50LatencyMs: 8
+                    p95LatencyMs: 14
+          - targetArea:
+              areaId: "athens"
+            edgeCloudZoneViabilities: []

--- a/code/API_definitions/optimal-edge-discovery.yaml
+++ b/code/API_definitions/optimal-edge-discovery.yaml
@@ -40,10 +40,11 @@ info:
         region. This can be achieved using the
         `/retrieve-optimal-edge-cloud-zones` API.
 
-        The same operation can also be used before deployment to evaluate which
+    - **Pre-deployment Edge Cloud Zone Viability Discovery**: To evaluate which
         edge cloud zones known to the API Publisher are viable candidates for
         target areas and an application profile before any active device or
-        user session exists.
+        user session exists. This can be achieved using the
+        `/retrieve-viable-edge-cloud-zones` API.
 
     The pre-deployment operation is planning-oriented. It returns planning
     estimates only and does not provide runtime steering, traffic-routing
@@ -101,13 +102,13 @@ info:
 
     ## Error handling:
 
-    - If neither `device` nor `targetAreas` is provided in the request, then
-    the server will return an error with the `422 MISSING_IDENTIFIER` error
-    code.
+    - If the subject cannot be identified from the access token and the
+    optional `device` object is not included in the request, then the server
+    will return an error with the `422 MISSING_IDENTIFIER` error code.
 
-    - If both `device` and `targetAreas` are provided in the request, then the
-    server will return a `400 INVALID_ARGUMENT` error because the request mixes
-    the device-specific and planning discovery modes.
+    - If the subject can be identified from the access token and the optional
+    `device` object is also included in the request, then the server will
+    return an error with the `422 UNNECESSARY_IDENTIFIER` error code.
 
     # Responses
 
@@ -163,10 +164,11 @@ info:
     will not be present in the response, and the `applicationProfileId` will
     be the only field returned.
 
-    For pre-deployment planning requests, the API consumer provides
-    `targetAreas` instead of a device identifier. The response can include
-    `areaResults` with planning viability, served target areas, abstract
-    planning classes, and estimated metrics for candidate edge cloud zones.
+    For pre-deployment planning, the API consumer can use
+    `/retrieve-viable-edge-cloud-zones` with `targetAreas` instead of a device
+    identifier. The response can include `areaResults` with planning viability,
+    served target areas, abstract planning classes, and estimated metrics for
+    candidate edge cloud zones.
 
     ## Errors
 
@@ -305,22 +307,20 @@ paths:
       parameters:
         - $ref: "#/components/parameters/x-correlator"
       requestBody:
-        required: true
+        required: false
         content:
           application/json:
             schema:
               $ref: "#/components/schemas/OptimalEdgeDiscoveryInfo"
             examples:
+              Identify Device By 3-Legged Access Token:
+                $ref: '#/components/examples/IdentifyDeviceBy3LeggedToken'
               Identify Device By Phone Number:
                 $ref: '#/components/examples/IdentifyDeviceByPhoneNumber'
               Identify Device By IP Address:
                 $ref: '#/components/examples/IdentifyDeviceByIPAddress'
               Identify Device By Multiple Identifiers:
                 $ref: '#/components/examples/IdentifyDeviceByMultipleIdentifiers'
-              Pre-deployment Planning By Target Areas:
-                $ref: "#/components/examples/PreDeploymentPlanningRequest"
-              Pre-deployment Planning Including Non-viable Candidates:
-                $ref: "#/components/examples/PreDeploymentPlanningWithNonViableRequest"
 
       responses:
         "200":
@@ -333,6 +333,58 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/EdgeDiscoveryResponse"
+        "400":
+          $ref: "#/components/responses/Generic400"
+        "401":
+          $ref: "#/components/responses/Generic401"
+        "403":
+          $ref: "#/components/responses/Generic403"
+        "404":
+          $ref: "#/components/responses/Generic404"
+        "422":
+          $ref: "#/components/responses/Generic422"
+        "429":
+          $ref: "#/components/responses/Generic429"
+      tags:
+        - Discovery
+      summary: Discover optimal edge cloud zones for deployed applications
+      description: Returns a list of optimal edge cloud zones where you can
+         register your deployed application. You can choose to search without
+         passing any of the inputs parameters or a combination of Application
+         Profile and device information.
+  /retrieve-viable-edge-cloud-zones:
+    post:
+      operationId: retrieveViableEdgeCloudZones
+      security:
+        - openId:
+            - "optimal-edge-discovery:viable-edge-zones:read"
+      parameters:
+        - $ref: "#/components/parameters/x-correlator"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PreDeploymentEdgeDiscoveryInfo"
+            examples:
+              Pre-deployment Planning By Target Areas:
+                $ref: "#/components/examples/PreDeploymentPlanningRequest"
+              Pre-deployment Planning Including Non-viable Candidates:
+                $ref: "#/components/examples/PreDeploymentPlanningWithNonViableRequest"
+
+      responses:
+        "200":
+          description: |
+            Returns edge cloud zone viability results for pre-deployment
+            planning. Results are estimates and are not runtime performance
+            guarantees.
+          headers:
+            x-correlator:
+              $ref: "#/components/headers/x-correlator"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PreDeploymentEdgeDiscoveryResponse"
               examples:
                 Pre-deployment Planning Results:
                   $ref: "#/components/examples/PreDeploymentPlanningResponse"
@@ -352,14 +404,16 @@ paths:
           $ref: "#/components/responses/Generic429"
       tags:
         - Discovery
-      summary: Discover optimal edge cloud zones for deployed applications
+      summary: Retrieve viable edge cloud zones for pre-deployment planning
       description: |
-        Returns a list of optimal edge cloud zones where you can register your
-        deployed application. You can choose to search with a combination of
-        Application Profile and device information, or with target areas for
-        pre-deployment planning. Planning results are estimates only and do not
-        represent runtime steering, routing, topology, reservations, SLAs, or
-        future performance guarantees.
+        Evaluates which edge cloud zones known to the API Publisher are viable
+        candidates for target geographic areas and an application profile
+        before deployment.
+
+        The operation does not require an active device and does not return
+        runtime steering, routing, topology, UPF, DNN, S-NSSAI, or other
+        operator-internal details. Estimated metrics are planning indicators
+        only and must not be interpreted as runtime guarantees.
 
 components:
   securitySchemes:
@@ -386,28 +440,44 @@ components:
     EdgeDiscoveryResponse:
       type: object
       description: |
-        Response for the optimal edge discovery API. It contains edge cloud
-        zones that match the query parameters. For target-area planning
-        requests, it can also contain area-specific viability results.
+        Response for the optimal edge discovery API. It contains a list of
+        edge cloud zones that match the query parameters.
       properties:
         edgeCloudZones:
           type: array
           items:
             $ref: "#/components/schemas/EdgeCloudZone"
-          description: |
-            Candidate edge cloud zones that match the request. For device
-            discovery requests, this is the primary result list. For
-            pre-deployment planning requests, this field is optional summary
-            output containing selected candidates across the requested target
-            areas; `areaResults` is the authoritative per-area planning result.
+          minItems: 1
         applicationProfileId:
           $ref: "#/components/schemas/ApplicationProfileId"
         device:
           $ref: "#/components/schemas/DeviceResponse"
+
+    PreDeploymentEdgeDiscoveryResponse:
+      type: object
+      description: |
+        Response for pre-deployment edge cloud zone viability discovery.
+        `edgeCloudZones` is the canonical list of candidate edge cloud zone
+        resources. Area-specific viability results reference candidates by
+        `edgeCloudZoneId` and contain only planning-specific assessment fields.
+      required:
+        - applicationProfileId
+        - edgeCloudZones
+        - areaResults
+        - validUntil
+      properties:
+        applicationProfileId:
+          $ref: "#/components/schemas/ApplicationProfileId"
+        edgeCloudZones:
+          description: |
+            Canonical list of edge cloud zone resources referenced by
+            `areaResults`.
+          type: array
+          items:
+            $ref: "#/components/schemas/EdgeCloudZone"
         areaResults:
           description: |
-            Area-specific planning results. This field is returned when the
-            request includes `targetAreas`.
+            Area-specific planning results.
           type: array
           minItems: 1
           items:
@@ -497,33 +567,41 @@ components:
 
     OptimalEdgeDiscoveryInfo:
       description: |
-        Resource to obtain optimal edge cloud zones for a given application
-        profile. A request can identify a device for user-proximity discovery,
-        or provide target areas and planning criteria for pre-deployment
-        discovery before any active device or user session exists. Application
-        network and compute requirements are referenced through
-        `applicationProfileId`.
-
-        Exactly one discovery mode must be selected: provide `device` for
-        device-specific discovery, or provide `targetAreas` for
-        pre-deployment planning discovery. Requests that provide neither field,
-        or both fields, are invalid. Planning-only fields
-        `networkOperatorCriteria`, `maxResults`, and
-        `includeNonViableCandidates` must not be sent with device-specific
-        discovery requests. This is expressed with `oneOf` and `not`; API
-        providers should enforce the same validation even when tooling does not
-        fully enforce these OpenAPI semantics.
+        Resource to obtain the optimal edge cloud zone for a given application
+        profile and device information. The API returns the closest Edge Cloud
+        Zone to a given device, so the device needs to be identifiable by the
+        network. This can be achieved either by passing a device identifier in
+        the request header, or, from the 3-legged access token where implemented
+        by the operator.
       type: object
       properties:
         device:
           $ref: "#/components/schemas/Device"
         applicationProfileId:
           $ref: "#/components/schemas/ApplicationProfileId"
+        edgeCloudRegion:
+          $ref: "#/components/schemas/EdgeCloudRegion"
+      required:
+        - applicationProfileId
+
+    PreDeploymentEdgeDiscoveryInfo:
+      description: |
+        Request resource to retrieve viable edge cloud zones for
+        pre-deployment planning. The request is not associated with an active
+        device or session. Application network and compute requirements are
+        referenced through `applicationProfileId`; this request only describes
+        target areas and optional planning criteria.
+      type: object
+      required:
+        - applicationProfileId
+        - targetAreas
+      properties:
+        applicationProfileId:
+          $ref: "#/components/schemas/ApplicationProfileId"
         targetAreas:
           description: |
             Target demand or service areas for which edge cloud zone viability
-            is evaluated before deployment. When this field is present, the
-            response can include `areaResults`.
+            is evaluated before deployment.
           type: array
           minItems: 1
           items:
@@ -546,26 +624,6 @@ components:
             `CONDITIONALLY_VIABLE` results are returned.
           type: boolean
           default: false
-      required:
-        - applicationProfileId
-      oneOf:
-        - required:
-            - device
-          not:
-            anyOf:
-              - required:
-                  - targetAreas
-              - required:
-                  - networkOperatorCriteria
-              - required:
-                  - maxResults
-              - required:
-                  - includeNonViableCandidates
-        - required:
-            - targetAreas
-          not:
-            required:
-              - device
 
     AreaEdgeCloudZoneViabilityResult:
       description: Viability results for a requested target area.
@@ -588,11 +646,11 @@ components:
         topology or policy.
       type: object
       required:
-        - edgeCloudZone
+        - edgeCloudZoneId
         - viability
       properties:
-        edgeCloudZone:
-          $ref: "#/components/schemas/EdgeCloudZone"
+        edgeCloudZoneId:
+          $ref: "#/components/schemas/EdgeCloudZoneId"
         viability:
           type: string
           description: |
@@ -1121,12 +1179,13 @@ components:
                 code: SERVICE_NOT_APPLICABLE
                 message: The service is not available for the provided identifier.
             GENERIC_422_MISSING_IDENTIFIER:
-              description: Neither a device identifier nor target areas are
-                included in the request.
+              description: An identifier is not included in the request and the
+                device or phone number identification cannot be derived from the
+                3-legged access token
               value:
                 status: 422
                 code: MISSING_IDENTIFIER
-                message: The device or target areas must be provided.
+                message: The device cannot be identified.
             GENERIC_422_UNSUPPORTED_IDENTIFIER:
               description: None of the provided identifiers is
                 supported by the implementation
@@ -1176,6 +1235,11 @@ components:
                 code: TOO_MANY_REQUESTS
                 message: Rate limit reached.
   examples:
+    IdentifyDeviceBy3LeggedToken:
+      description: Empty JSON when device is identified by access token
+      value:
+        applicationProfileId: "2fa85f64-5717-4562-b3fc-2c963f66afa0"
+
     IdentifyDeviceByPhoneNumber:
       description: Identifying device by phone number
       value:
@@ -1206,7 +1270,7 @@ components:
     PreDeploymentPlanningRequest:
       description: |
         Discover viable edge cloud zones for a cloud gaming application profile
-        before deployment using the optimal edge discovery operation.
+        before deployment using the viability discovery operation.
       value:
         targetAreas:
           - area:
@@ -1262,6 +1326,11 @@ components:
             edgeCloudProvider: "EdgeCo Neutral Host"
             edgeCloudRegion: "gr-west-1"
             edgeCloudZoneStatus: active
+          - edgeCloudZoneId: "a785db91-462a-40c6-b963-fdc98940f255"
+            edgeCloudZoneName: "GR West Zone B"
+            edgeCloudProvider: "EdgeCo Neutral Host"
+            edgeCloudRegion: "gr-west-1"
+            edgeCloudZoneStatus: active
         areaResults:
           - targetArea:
               area:
@@ -1271,12 +1340,7 @@ components:
                   longitude: 21.7346
                 radius: 5000
             edgeCloudZoneViabilities:
-              - edgeCloudZone:
-                  edgeCloudZoneId: "4f7b5555-6457-4890-9d4e-1dc79f44ab66"
-                  edgeCloudZoneName: "GR West Zone A"
-                  edgeCloudProvider: "EdgeCo Neutral Host"
-                  edgeCloudRegion: "gr-west-1"
-                  edgeCloudZoneStatus: active
+              - edgeCloudZoneId: "4f7b5555-6457-4890-9d4e-1dc79f44ab66"
                 viability: VIABLE
                 networkOperatorPlanningInfo:
                   planningClasses:
@@ -1285,12 +1349,7 @@ components:
                   latencyEstimate:
                     p50LatencyMs: 8
                     p95LatencyMs: 14
-              - edgeCloudZone:
-                  edgeCloudZoneId: "a785db91-462a-40c6-b963-fdc98940f255"
-                  edgeCloudZoneName: "GR West Zone B"
-                  edgeCloudProvider: "EdgeCo Neutral Host"
-                  edgeCloudRegion: "gr-west-1"
-                  edgeCloudZoneStatus: active
+              - edgeCloudZoneId: "a785db91-462a-40c6-b963-fdc98940f255"
                 viability: CONDITIONALLY_VIABLE
                 conditionInfo:
                   conditionType: SERVICE_ACTIVATION_REQUIRED
@@ -1317,7 +1376,12 @@ components:
       value:
         applicationProfileId: "2fa85f64-5717-4562-b3fc-2c963f66afa0"
         validUntil: "2026-05-19T12:15:00Z"
-        edgeCloudZones: []
+        edgeCloudZones:
+          - edgeCloudZoneId: "dc10c463-d604-4f2f-a002-c1199de12d6f"
+            edgeCloudZoneName: "GR West Zone C"
+            edgeCloudProvider: "EdgeCo Neutral Host"
+            edgeCloudRegion: "gr-west-1"
+            edgeCloudZoneStatus: active
         areaResults:
           - targetArea:
               area:
@@ -1327,12 +1391,7 @@ components:
                   longitude: 21.7346
                 radius: 5000
             edgeCloudZoneViabilities:
-              - edgeCloudZone:
-                  edgeCloudZoneId: "dc10c463-d604-4f2f-a002-c1199de12d6f"
-                  edgeCloudZoneName: "GR West Zone C"
-                  edgeCloudProvider: "EdgeCo Neutral Host"
-                  edgeCloudRegion: "gr-west-1"
-                  edgeCloudZoneStatus: active
+              - edgeCloudZoneId: "dc10c463-d604-4f2f-a002-c1199de12d6f"
                 viability: NOT_VIABLE
                 viabilityReason: "The requested application profile requirements cannot be met for this target area."
                 estimatedMetrics:

--- a/code/API_definitions/optimal-edge-discovery.yaml
+++ b/code/API_definitions/optimal-edge-discovery.yaml
@@ -46,13 +46,6 @@ info:
         user session exists. This can be achieved using the
         `/retrieve-viable-edge-cloud-zones` API.
 
-    The pre-deployment operation is planning-oriented. It returns planning
-    estimates only and does not provide runtime steering, traffic-routing
-    instructions, or guarantees about future network performance. The API
-    intentionally exposes only public planning abstractions and does not expose
-    UPF, DNN, S-NSSAI, routing policy, topology, or other internal operator
-    details.
-
     To call these endpoints, the API consumer must first obtain a valid OAuth2 token
     from the token endpoint, and pass it as an `Authorization` header in the API
     request.
@@ -102,13 +95,14 @@ info:
 
     ## Error handling:
 
-    - If the subject cannot be identified from the access token and the
-    optional `device` object is not included in the request, then the server
-    will return an error with the `422 MISSING_IDENTIFIER` error code.
+    - If the subject cannot be identified from the access token and the optional `device`
+    object is not included in the request, then the server will return an error with the
+    `422 MISSING_IDENTIFIER` error code.
 
-    - If the subject can be identified from the access token and the optional
-    `device` object is also included in the request, then the server will
-    return an error with the `422 UNNECESSARY_IDENTIFIER` error code.
+    - If the subject can be identified from the access token and the optional `device`
+    object is also included in the request, then the server will return an error with the
+    `422 UNNECESSARY_IDENTIFIER` error code. This will be the case even if the same device
+    is identified by these two methods, as the server is unable to make this comparison.
 
     # Responses
 
@@ -163,12 +157,6 @@ info:
     If the device was identified from the access token, the `device` object
     will not be present in the response, and the `applicationProfileId` will
     be the only field returned.
-
-    For pre-deployment planning, the API consumer can use
-    `/retrieve-viable-edge-cloud-zones` with `targetAreas` instead of a device
-    identifier. The response can include `areaResults` with planning viability,
-    served target areas, abstract planning classes, and estimated metrics for
-    candidate edge cloud zones.
 
     ## Errors
 
@@ -255,9 +243,8 @@ tags:
     description: |
       Discover the regions and zones in the edge cloud
       application, find optimal edge cloud zones for
-      your deployed applications, optimal Application
-      Endpoints for your clients to connect to, and viable
-      edge cloud zone candidates for pre-deployment planning.
+      your deployed applications, and optimal
+      Application Endpoints for your clients to connect to.
 ############################################################################
 #                                     Paths                                #
 ############################################################################
@@ -409,11 +396,6 @@ paths:
         Evaluates which edge cloud zones known to the API Publisher are viable
         candidates for target geographic areas and an application profile
         before deployment.
-
-        The operation does not require an active device and does not return
-        runtime steering, routing, topology, UPF, DNN, S-NSSAI, or other
-        operator-internal details. Estimated metrics are planning indicators
-        only and must not be interpreted as runtime guarantees.
 
 components:
   securitySchemes:

--- a/code/API_definitions/optimal-edge-discovery.yaml
+++ b/code/API_definitions/optimal-edge-discovery.yaml
@@ -40,13 +40,12 @@ info:
         region. This can be achieved using the
         `/retrieve-optimal-edge-cloud-zones` API.
 
-    - **Pre-deployment Edge Cloud Zone Viability Discovery**: To evaluate which
-        edge cloud zones known to the API Publisher are viable candidates for target areas and an
-        application profile before any active device or user session exists.
-        This can be achieved using the
-        `/retrieve-viable-edge-cloud-zones` API.
+        The same operation can also be used before deployment to evaluate which
+        edge cloud zones known to the API Publisher are viable candidates for
+        target areas and an application profile before any active device or
+        user session exists.
 
-    The pre-deployment operation is planning-oriented. It returns planning
+    Pre-deployment discovery is planning-oriented. It returns planning
     estimates only and does not provide runtime steering, traffic-routing
     instructions, or guarantees about future network performance. The API
     intentionally exposes only public planning abstractions and does not expose
@@ -59,14 +58,14 @@ info:
 
     # Identifying the device
 
-    The API returns the closest Edge Cloud Zone to a given device, so that
-    device needs to be identifiable by the network. This can be achieved either
-    by passing one or more device identifiers in the request, or, from the
-    three-legged access token where implemented by the operator.
+    For device-specific discovery, the API returns the closest Edge Cloud Zone
+    to a given device, so that device needs to be identifiable by the network.
+    This can be achieved by passing one or more device identifiers in the
+    request.
 
     ## Passing device identifier(s) in the request
-    At least one of the following device identifiers must be provided, unless
-    using a 3-legged access toekn (see next section):
+    At least one of the following device identifiers must be provided for
+    device-specific discovery:
      - Phone number (i.e. MSISDN)
      - Network Access Identifier assigned by the mobile network operator for the device
      - IPv6 address
@@ -84,32 +83,15 @@ info:
     is concluded and the relevant issues are resolved, its use will need to be
     explicitly documented in the guidelines.
 
-
-    ## Identifying the device from the access token
-
-    This API requires the API consumer to identify a device as the subject of
-    the API as follows:
-
-    - When the API is invoked using a two-legged access token, the subject will be
-    identified from the optional `device` object, which therefore MUST be provided.
-    - When a three-legged access token is used however, this optional identifier
-    MUST NOT be provided, as the subject will be uniquely identified from the access
-    token.
-
-    This approach simplifies API usage for API consumers using a three-legged access
-    token to invoke the API by relying on the information that is associated with the
-    access token and was identified during the authentication process.
-
     ## Error handling:
 
-    - If the subject cannot be identified from the access token and the optional `device`
-    object is not included in the request, then the server will return an error with the
-    `422 MISSING_IDENTIFIER` error code.
+    - If neither `device` nor `targetAreas` is provided in the request, then
+    the server will return an error with the `422 MISSING_IDENTIFIER` error
+    code.
 
-    - If the subject can be identified from the access token and the optional `device`
-    object is also included in the request, then the server will return an error with the
-    `422 UNNECESSARY_IDENTIFIER` error code. This will be the case even if the same device
-    is identified by these two methods, as the server is unable to make this comparison.
+    - If both `device` and `targetAreas` are provided in the request, then the
+    server will return a `400 INVALID_ARGUMENT` error because the request mixes
+    the device-specific and planning discovery modes.
 
     # Responses
 
@@ -161,9 +143,11 @@ info:
       - `ipv6Address`: The public IPv6 address of the device.
     The response will contain only one of these identifiers, depending on
     which identifier was used to identify the device in the request.
-    If the device was identified from the access token, the `device` object
-    will not be present in the response, and the `applicationProfileId` will
-    be the only field returned.
+
+    For pre-deployment planning requests, the API consumer provides
+    `targetAreas` instead of a device identifier. The response can include
+    `areaResults` with planning viability, served target areas, abstract
+    planning classes, and estimated metrics for candidate edge cloud zones.
 
     ## Errors
 
@@ -232,7 +216,7 @@ externalDocs:
 #                                     Servers                              #
 ############################################################################
 servers:
-  - url: "{apiRoot}/optimal-edge-discovery/vwip"
+  - url: "{apiRoot}/optimal-edge-discovery/v0.1.0"
     variables:
       apiRoot:
         default: https://localhost:9091
@@ -248,11 +232,9 @@ tags:
       Get all Region IDs and Names for edge cloud zones
   - name: Discovery
     description: |
-      Discover the regions and zones in the edge cloud
-      application, find optimal edge cloud zones for
-      your deployed applications, optimal Application
-      Endpoints for your clients to connect to, and viable
-      edge cloud zone candidates for pre-deployment planning.
+      Discover the regions and zones in the edge cloud application and find
+      optimal edge cloud zones for deployed applications or pre-deployment
+      planning.
 ############################################################################
 #                                     Paths                                #
 ############################################################################
@@ -302,20 +284,22 @@ paths:
       parameters:
         - $ref: "#/components/parameters/x-correlator"
       requestBody:
-        required: false
+        required: true
         content:
           application/json:
             schema:
               $ref: "#/components/schemas/OptimalEdgeDiscoveryInfo"
             examples:
-              Identify Device By 3-Legged Access Token:
-                $ref: '#/components/examples/IdentifyDeviceBy3LeggedToken'
               Identify Device By Phone Number:
                 $ref: '#/components/examples/IdentifyDeviceByPhoneNumber'
               Identify Device By IP Address:
                 $ref: '#/components/examples/IdentifyDeviceByIPAddress'
               Identify Device By Multiple Identifiers:
                 $ref: '#/components/examples/IdentifyDeviceByMultipleIdentifiers'
+              Pre-deployment Planning By Target Areas:
+                $ref: "#/components/examples/PreDeploymentPlanningRequest"
+              Pre-deployment Planning Including Non-viable Candidates:
+                $ref: "#/components/examples/PreDeploymentPlanningWithNonViableRequest"
 
       responses:
         "200":
@@ -328,58 +312,11 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/EdgeDiscoveryResponse"
-        "400":
-          $ref: "#/components/responses/Generic400"
-        "401":
-          $ref: "#/components/responses/Generic401"
-        "403":
-          $ref: "#/components/responses/Generic403"
-        "404":
-          $ref: "#/components/responses/Generic404"
-        "422":
-          $ref: "#/components/responses/Generic422"
-        "429":
-          $ref: "#/components/responses/Generic429"
-      tags:
-        - Discovery
-      summary: Discover optimal edge cloud zones for deployed applications
-      description: Returns a list of optimal edge cloud zones where you can
-         register your deployed application. You can choose to search without
-         passing any of the inputs parameters or a combination of Application
-         Profile and device information.
-  /retrieve-viable-edge-cloud-zones:
-    post:
-      operationId: retrieveViableEdgeCloudZones
-      security:
-        - openId:
-            - "optimal-edge-discovery:viable-edge-zones:read"
-      parameters:
-        - $ref: "#/components/parameters/x-correlator"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PreDeploymentEdgeDiscoveryInfo"
-            examples:
-              Retrieve Viable Edge Cloud Zones:
-                $ref: "#/components/examples/RetrieveViableEdgeCloudZonesRequest"
-      responses:
-        "200":
-          description: |
-            Returns edge cloud zone viability results for pre-deployment
-            planning. Results are estimates and are not runtime performance
-            guarantees.
-          headers:
-            x-correlator:
-              $ref: "#/components/headers/x-correlator"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PreDeploymentEdgeDiscoveryResponse"
               examples:
-                Viable Edge Cloud Zones:
-                  $ref: "#/components/examples/RetrieveViableEdgeCloudZonesResponse"
+                Pre-deployment Planning Results:
+                  $ref: "#/components/examples/PreDeploymentPlanningResponse"
+                Pre-deployment Planning Results Including Non-viable Candidates:
+                  $ref: "#/components/examples/PreDeploymentPlanningWithNonViableResponse"
         "400":
           $ref: "#/components/responses/Generic400"
         "401":
@@ -394,16 +331,17 @@ paths:
           $ref: "#/components/responses/Generic429"
       tags:
         - Discovery
-      summary: Retrieve viable edge cloud zones for pre-deployment planning
+      summary: Discover optimal edge cloud zones
       description: |
-        Evaluates which edge cloud zones are viable for target geographic
-        areas, an application profile, and optional planning criteria before
-        deployment.
+        Returns a list of optimal edge cloud zones where an application can be
+        deployed or registered. The request must provide either `device` for
+        device-specific discovery, or `targetAreas` for pre-deployment planning
+        before any active device or user session exists.
 
-        The operation does not require an active device and does not return
-        runtime steering, routing, topology, UPF, DNN, S-NSSAI, or other
-        operator-internal details. Estimated metrics are planning indicators
-        only and must not be interpreted as runtime guarantees.
+        When `targetAreas` are provided, returned viability and metric values
+        are planning indicators only. They do not represent runtime steering,
+        routing, topology, UPF, DNN, S-NSSAI, operator-internal details,
+        reservations, SLAs, or future performance guarantees.
 
 components:
   securitySchemes:
@@ -430,18 +368,39 @@ components:
     EdgeDiscoveryResponse:
       type: object
       description: |
-        Response for the optimal edge discovery API. It contains a list of
-        edge cloud zones that match the query parameters.
+        Response for the optimal edge discovery API. It contains edge cloud
+        zones that match the query parameters. For target-area planning
+        requests, it can also contain area-specific viability results.
       properties:
         edgeCloudZones:
           type: array
           items:
             $ref: "#/components/schemas/EdgeCloudZone"
-          minItems: 1
+          description: |
+            Candidate edge cloud zones that match the request. For device
+            discovery requests, this is the primary result list. For
+            pre-deployment planning requests, this field is optional summary
+            output containing selected candidates across the requested target
+            areas; `areaResults` is the authoritative per-area planning result.
         applicationProfileId:
           $ref: "#/components/schemas/ApplicationProfileId"
         device:
           $ref: "#/components/schemas/DeviceResponse"
+        areaResults:
+          description: |
+            Area-specific planning results. This field is returned when the
+            request includes `targetAreas`.
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/AreaEdgeCloudZoneViabilityResult"
+        validUntil:
+          description: |
+            Timestamp until which the API provider considers this planning
+            response fresh enough for pre-deployment decision making. This is
+            not a runtime availability guarantee, reservation, or SLA.
+          type: string
+          format: date-time
 
     EdgeCloudZone:
       type: object
@@ -520,52 +479,44 @@ components:
 
     OptimalEdgeDiscoveryInfo:
       description: |
-        Resource to obtain the optimal edge cloud zone for a given application
-        profile and device information. The API returns the closest Edge Cloud
-        Zone to a given device, so the device needs to be identifiable by the
-        network. This can be achieved either by passing a device identifier in
-        the request header, or, from the 3-legged access token where implemented
-        by the operator.
+        Resource to obtain optimal edge cloud zones for a given application
+        profile. A request can identify a device for user-proximity discovery,
+        or provide target areas and planning criteria for pre-deployment
+        discovery before any active device or user session exists. Application
+        network and compute requirements are referenced through
+        `applicationProfileId`.
+
+        Exactly one discovery mode must be selected: provide `device` for
+        device-specific discovery, or provide `targetAreas` for
+        pre-deployment planning discovery. Requests that provide neither field,
+        or both fields, are invalid. Planning-only fields
+        `networkOperatorCriteria`, `maxResults`, and
+        `includeNonViableCandidates` must not be sent with device-specific
+        discovery requests. This is expressed with `oneOf` and `not`; API
+        providers should enforce the same validation even when tooling does not
+        fully enforce these OpenAPI semantics.
       type: object
       properties:
         device:
           $ref: "#/components/schemas/Device"
         applicationProfileId:
           $ref: "#/components/schemas/ApplicationProfileId"
-        edgeCloudRegion:
-          $ref: "#/components/schemas/EdgeCloudRegion"
-      required:
-        - applicationProfileId
-
-    PreDeploymentEdgeDiscoveryInfo:
-      description: |
-        Request resource to retrieve viable edge cloud zones for
-        pre-deployment planning. The request is not associated with an active
-        device or session. Application network and compute requirements are
-        referenced through `applicationProfileId`; this request only describes
-        target areas and optional planning criteria.
-      type: object
-      required:
-        - targetAreas
-        - applicationProfileId
-      properties:
         targetAreas:
           description: |
             Target demand or service areas for which edge cloud zone viability
-            is evaluated.
+            is evaluated before deployment. When this field is present, the
+            response can include `areaResults`.
           type: array
           minItems: 1
           items:
             $ref: "#/components/schemas/TargetArea"
-        applicationProfileId:
-          $ref: "#/components/schemas/ApplicationProfileId"
         edgeCloudZoneCriteria:
           $ref: "#/components/schemas/EdgeCloudZoneCriteria"
         networkOperatorCriteria:
           $ref: "#/components/schemas/NetworkOperatorCriteria"
         maxResults:
-          description: Maximum number of viability results to return per
-            target area.
+          description: Maximum number of planning results to return per target
+            area.
           type: integer
           minimum: 1
           maximum: 100
@@ -573,36 +524,30 @@ components:
         includeNonViableCandidates:
           description: |
             Indicates whether results with `NOT_VIABLE` or `UNKNOWN` viability
-            can be included in the response. When false, only `VIABLE` and
-            `PARTIALLY_VIABLE` results are returned.
+            can be included in planning results. When false, only `VIABLE` and
+            `CONDITIONALLY_VIABLE` results are returned.
           type: boolean
           default: false
-
-    PreDeploymentEdgeDiscoveryResponse:
-      description: |
-        Response resource containing edge cloud zone viability results for
-        pre-deployment planning. Results are planning estimates and do not
-        represent runtime availability guarantees, reservations, or SLAs.
-      type: object
       required:
         - applicationProfileId
-        - areaResults
-        - validUntil
-      properties:
-        applicationProfileId:
-          $ref: "#/components/schemas/ApplicationProfileId"
-        areaResults:
-          type: array
-          minItems: 1
-          items:
-            $ref: "#/components/schemas/AreaEdgeCloudZoneViabilityResult"
-        validUntil:
-          description: |
-            Timestamp until which the API provider considers this planning
-            response fresh enough for pre-deployment decision making. This is
-            not a runtime availability guarantee, reservation, or SLA.
-          type: string
-          format: date-time
+      oneOf:
+        - required:
+            - device
+          not:
+            anyOf:
+              - required:
+                  - targetAreas
+              - required:
+                  - networkOperatorCriteria
+              - required:
+                  - maxResults
+              - required:
+                  - includeNonViableCandidates
+        - required:
+            - targetAreas
+          not:
+            required:
+              - device
 
     AreaEdgeCloudZoneViabilityResult:
       description: Viability results for a requested target area.
@@ -637,24 +582,62 @@ components:
             area and application profile.
           enum:
             - VIABLE
-            - PARTIALLY_VIABLE
+            - CONDITIONALLY_VIABLE
             - NOT_VIABLE
             - UNKNOWN
+        conditionInfo:
+          description: |
+            Additional condition details. This field is required by API
+            semantics when `viability` is `CONDITIONALLY_VIABLE` and should be
+            omitted for straightforward `VIABLE` results. OpenAPI 3.0 does not
+            enforce this conditional requirement cleanly.
+          allOf:
+            - $ref: "#/components/schemas/ConditionInfo"
         viabilityReason:
           description: |
-            Optional human-readable explanation for partial, non-viable, or
-            unknown results. This field should be omitted for straightforward
-            `VIABLE` results.
+            Optional human-readable explanation for conditional, non-viable,
+            or unknown results. This field should be omitted for
+            straightforward `VIABLE` results.
           type: string
-        supportedAreas:
-          description: Areas supported by this edge cloud zone for planning.
+        servedTargetAreas:
+          description: |
+            Requested target areas that can be served by this candidate edge
+            cloud zone. This can include other target areas from the same
+            request in addition to the `targetArea` of the current per-area
+            result.
           type: array
           items:
             $ref: "#/components/schemas/TargetArea"
-        networkOperatorCommercialInfo:
-          $ref: "#/components/schemas/NetworkOperatorCommercialInfo"
+        networkOperatorPlanningInfo:
+          $ref: "#/components/schemas/NetworkOperatorPlanningInfo"
         estimatedMetrics:
           $ref: "#/components/schemas/EstimatedMetrics"
+
+    ConditionInfo:
+      description: |
+        Additional information for a `CONDITIONALLY_VIABLE` result.
+      type: object
+      required:
+        - conditionType
+        - expectedActivationDelay
+        - description
+      properties:
+        conditionType:
+          description: Type of condition that must be satisfied.
+          type: string
+          enum:
+            - CAPACITY_EXPANSION_REQUIRED
+            - MANUAL_APPROVAL_REQUIRED
+            - SERVICE_ACTIVATION_REQUIRED
+            - OTHER
+        expectedActivationDelay:
+          description: Expected time before the edge cloud zone can become viable.
+          type: string
+          format: duration
+          example: "PT1H"
+        description:
+          description: Human-readable description of the condition.
+          type: string
 
     EdgeCloudZoneCriteria:
       description: Optional edge-cloud-zone candidate criteria.
@@ -679,32 +662,31 @@ components:
         details.
       type: object
       properties:
-        pricingTiers:
+        planningClasses:
           description: |
-            Broad network-operator commercial planning classes to consider.
-            These values are not price quotes and do not represent edge cloud
-            provider pricing.
+            Broad non-sensitive planning classes to consider. These values are
+            not contract terms, prices, quotes, SLAs, or commercial commitments.
           type: array
           minItems: 1
           items:
-            $ref: "#/components/schemas/PricingTier"
+            $ref: "#/components/schemas/PlanningClass"
       minProperties: 1
 
-    NetworkOperatorCommercialInfo:
+    NetworkOperatorPlanningInfo:
       description: |
-        Broad network-operator-side commercial planning information associated
-        with a candidate edge cloud zone. This is not an edge cloud provider
-        price and is not a binding quote.
+        Broad non-sensitive network-operator-side planning information
+        associated with a candidate edge cloud zone. This is not a contract,
+        price, quote, SLA, or commercial commitment.
       type: object
       properties:
-        pricingTiers:
+        planningClasses:
           type: array
           minItems: 1
           items:
-            $ref: "#/components/schemas/PricingTier"
+            $ref: "#/components/schemas/PlanningClass"
 
-    PricingTier:
-      description: Broad network-operator commercial planning class.
+    PlanningClass:
+      description: Broad non-sensitive network-operator planning class.
       type: string
       enum:
         - STANDARD
@@ -1061,13 +1043,12 @@ components:
                 code: SERVICE_NOT_APPLICABLE
                 message: The service is not available for the provided identifier.
             GENERIC_422_MISSING_IDENTIFIER:
-              description: An identifier is not included in the request and the
-                device or phone number identification cannot be derived from the
-                3-legged access token
+              description: Neither a device identifier nor target areas are
+                included in the request.
               value:
                 status: 422
                 code: MISSING_IDENTIFIER
-                message: The device cannot be identified.
+                message: The device or target areas must be provided.
             GENERIC_422_UNSUPPORTED_IDENTIFIER:
               description: None of the provided identifiers is
                 supported by the implementation
@@ -1117,11 +1098,6 @@ components:
                 code: TOO_MANY_REQUESTS
                 message: Rate limit reached.
   examples:
-    IdentifyDeviceBy3LeggedToken:
-      description: Empty JSON when device is identified by access token
-      value:
-        applicationProfileId: "2fa85f64-5717-4562-b3fc-2c963f66afa0"
-
     IdentifyDeviceByPhoneNumber:
       description: Identifying device by phone number
       value:
@@ -1149,10 +1125,10 @@ components:
             publicPort: 59765
           networkAccessIdentifier: "123456789@domain.com"
 
-    RetrieveViableEdgeCloudZonesRequest:
+    PreDeploymentPlanningRequest:
       description: |
-        Retrieve viable edge cloud zones for a cloud gaming application profile
-        before deployment.
+        Discover viable edge cloud zones for a cloud gaming application profile
+        before deployment using the optimal edge discovery operation.
       value:
         targetAreas:
           - areaId: "patras"
@@ -1163,17 +1139,36 @@ components:
           edgeCloudProviders:
             - "EdgeCo Neutral Host"
         networkOperatorCriteria:
-          pricingTiers:
+          planningClasses:
             - STANDARD
             - PREMIUM
         maxResults: 4
         includeNonViableCandidates: false
 
-    RetrieveViableEdgeCloudZonesResponse:
+    PreDeploymentPlanningWithNonViableRequest:
+      description: |
+        Discover edge cloud zone candidates and include non-viable or unknown
+        planning results.
+      value:
+        targetAreas:
+          - areaId: "patras"
+        applicationProfileId: "2fa85f64-5717-4562-b3fc-2c963f66afa0"
+        edgeCloudZoneCriteria:
+          edgeCloudRegion: "gr-west-1"
+        maxResults: 4
+        includeNonViableCandidates: true
+
+    PreDeploymentPlanningResponse:
       description: Viable edge cloud zone planning response.
       value:
         applicationProfileId: "2fa85f64-5717-4562-b3fc-2c963f66afa0"
         validUntil: "2026-05-19T12:15:00Z"
+        edgeCloudZones:
+          - edgeCloudZoneId: "4f7b5555-6457-4890-9d4e-1dc79f44ab66"
+            edgeCloudZoneName: "GR West Zone A"
+            edgeCloudProvider: "EdgeCo Neutral Host"
+            edgeCloudRegion: "gr-west-1"
+            edgeCloudZoneStatus: active
         areaResults:
           - targetArea:
               areaId: "patras"
@@ -1185,17 +1180,61 @@ components:
                   edgeCloudRegion: "gr-west-1"
                   edgeCloudZoneStatus: active
                 viability: VIABLE
-                supportedAreas:
+                servedTargetAreas:
                   - areaId: "patras"
                   - areaId: "ioannina"
                   - areaId: "larissa"
-                networkOperatorCommercialInfo:
-                  pricingTiers:
+                networkOperatorPlanningInfo:
+                  planningClasses:
                     - PREMIUM
                 estimatedMetrics:
                   latencyEstimate:
                     p50LatencyMs: 8
                     p95LatencyMs: 14
+              - edgeCloudZone:
+                  edgeCloudZoneId: "a785db91-462a-40c6-b963-fdc98940f255"
+                  edgeCloudZoneName: "GR West Zone B"
+                  edgeCloudProvider: "EdgeCo Neutral Host"
+                  edgeCloudRegion: "gr-west-1"
+                  edgeCloudZoneStatus: active
+                viability: CONDITIONALLY_VIABLE
+                conditionInfo:
+                  conditionType: SERVICE_ACTIVATION_REQUIRED
+                  expectedActivationDelay: "PT1H"
+                  description: "Service activation is required before deployment."
+                servedTargetAreas:
+                  - areaId: "patras"
+                networkOperatorPlanningInfo:
+                  planningClasses:
+                    - STANDARD
+                estimatedMetrics:
+                  latencyEstimate:
+                    p50LatencyMs: 11
+                    p95LatencyMs: 18
           - targetArea:
               areaId: "athens"
             edgeCloudZoneViabilities: []
+
+    PreDeploymentPlanningWithNonViableResponse:
+      description: Planning response including a non-viable candidate.
+      value:
+        applicationProfileId: "2fa85f64-5717-4562-b3fc-2c963f66afa0"
+        validUntil: "2026-05-19T12:15:00Z"
+        edgeCloudZones: []
+        areaResults:
+          - targetArea:
+              areaId: "patras"
+            edgeCloudZoneViabilities:
+              - edgeCloudZone:
+                  edgeCloudZoneId: "dc10c463-d604-4f2f-a002-c1199de12d6f"
+                  edgeCloudZoneName: "GR West Zone C"
+                  edgeCloudProvider: "EdgeCo Neutral Host"
+                  edgeCloudRegion: "gr-west-1"
+                  edgeCloudZoneStatus: active
+                viability: NOT_VIABLE
+                viabilityReason: "The requested application profile requirements cannot be met for this target area."
+                servedTargetAreas: []
+                estimatedMetrics:
+                  latencyEstimate:
+                    p50LatencyMs: 35
+                    p95LatencyMs: 65

--- a/code/Test_definitions/optimal-edge-discovery.feature
+++ b/code/Test_definitions/optimal-edge-discovery.feature
@@ -1,5 +1,5 @@
   @Optimal_Edge_Discovery
-Feature: CAMARA Optimal Edge Discovery API, vwip - Operations for discovering optimal edge cloud zones
+Feature: CAMARA Optimal Edge Discovery API, v0.1.0 - Operations for discovering optimal edge cloud zones
 
 # Input to be provided by the implementation to the tests
 #
@@ -10,7 +10,7 @@ Feature: CAMARA Optimal Edge Discovery API, vwip - Operations for discovering op
 
   Background: Common Optimal Edge Discovery setup
     Given an environment at "apiRoot"
-    And the resource "/optimal-edge-discovery/vwip"
+    And the resource "/optimal-edge-discovery/v0.1.0"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
@@ -48,9 +48,20 @@ Feature: CAMARA Optimal Edge Discovery API, vwip - Operations for discovering op
     And the response body complies with the OAS schema at "/components/schemas/EdgeDiscoveryResponse"
     And the response contains filtered Edge Cloud Zones matching the specified parameters
 
+  @optimal_edge_discovery_04_discover_predeployment_edge_zones
+  Scenario: Discover viable Edge Cloud Zones for pre-deployment planning
+    Given a valid applicationProfileId is provided
+    And valid target areas are provided
+    And valid planning criteria for edge discovery are provided
+    When the request "discoverOptimalEdge" is sent with the applicationProfileId, target areas and planning criteria
+    Then the response code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response body complies with the OAS schema at "/components/schemas/EdgeDiscoveryResponse"
+    And the response contains area-specific Edge Cloud Zone viability results
+
 ######### Error Scenarios #################################
 
-  @optimal_edge_discovery_04_discover_edge_no_results
+  @optimal_edge_discovery_05_discover_edge_no_results
   Scenario: Discover Edge Cloud Zone with no matching results
     Given a valid device identifier in the system
     And a valid applicationProfileId is provided
@@ -61,7 +72,7 @@ Feature: CAMARA Optimal Edge Discovery API, vwip - Operations for discovering op
     And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
     And the response property "$.code" is "NOT_FOUND"
 
-  @optimal_edge_discovery_05_get_regions_unauthenticated
+  @optimal_edge_discovery_06_get_regions_unauthenticated
   Scenario: Get regions without authentication
     Given the header "Authorization" is not present
     When the request "getRegions" is sent
@@ -70,7 +81,7 @@ Feature: CAMARA Optimal Edge Discovery API, vwip - Operations for discovering op
     And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
     And the response property "$.code" is "UNAUTHENTICATED"
 
-  @optimal_edge_discovery_06_invalid_device_identifier
+  @optimal_edge_discovery_07_invalid_device_identifier
   Scenario: Discover optimal Edge Cloud Zone with invalid device identifier
     Given an invalid device identifier
     And a valid applicationProfileId is provided
@@ -80,7 +91,7 @@ Feature: CAMARA Optimal Edge Discovery API, vwip - Operations for discovering op
     And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
     And the response property "$.code" is "INVALID_ARGUMENT"
 
-  @optimal_edge_discovery_07_device_not_found
+  @optimal_edge_discovery_08_device_not_found
   Scenario: Discover optimal Edge Cloud Zone with non-existing device
     Given a non-existing device identifier
     And a valid applicationProfileId is provided
@@ -90,7 +101,7 @@ Feature: CAMARA Optimal Edge Discovery API, vwip - Operations for discovering op
     And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
     And the response property "$.code" is "IDENTIFIER_NOT_FOUND"
 
-  @optimal_edge_discovery_08_invalid_filter
+  @optimal_edge_discovery_09_invalid_filter
   Scenario: Discover optimal Edge Cloud Zone with invalid filter parameters
     Given a valid device identifier in the system
     And a valid applicationProfileId is provided
@@ -101,7 +112,7 @@ Feature: CAMARA Optimal Edge Discovery API, vwip - Operations for discovering op
     And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
     And the response property "$.code" is "INVALID_ARGUMENT"
 
-  @optimal_edge_discovery_09_unauthenticated
+  @optimal_edge_discovery_10_unauthenticated
   Scenario: Discover optimal Edge Cloud Zone without authentication
     Given a valid device identifier in the system
     And the header "Authorization" is not present

--- a/code/Test_definitions/optimal-edge-discovery.feature
+++ b/code/Test_definitions/optimal-edge-discovery.feature
@@ -48,15 +48,15 @@ Feature: CAMARA Optimal Edge Discovery API, vwip - Operations for discovering op
     And the response body complies with the OAS schema at "/components/schemas/EdgeDiscoveryResponse"
     And the response contains filtered Edge Cloud Zones matching the specified parameters
 
-  @optimal_edge_discovery_04_discover_predeployment_edge_zones
-  Scenario: Discover viable Edge Cloud Zones for pre-deployment planning
+  @optimal_edge_discovery_04_retrieve_viable_edge_cloud_zones
+  Scenario: Retrieve viable Edge Cloud Zones for pre-deployment planning
     Given a valid applicationProfileId is provided
     And valid target areas are provided
     And valid planning criteria for edge discovery are provided
-    When the request "discoverOptimalEdge" is sent with the applicationProfileId, target areas and planning criteria
+    When the request "retrieveViableEdgeCloudZones" is sent with the applicationProfileId, target areas and planning criteria
     Then the response code is 200
     And the response header "Content-Type" is "application/json"
-    And the response body complies with the OAS schema at "/components/schemas/EdgeDiscoveryResponse"
+    And the response body complies with the OAS schema at "/components/schemas/PreDeploymentEdgeDiscoveryResponse"
     And the response contains area-specific Edge Cloud Zone viability results
 
 ######### Error Scenarios #################################

--- a/code/Test_definitions/optimal-edge-discovery.feature
+++ b/code/Test_definitions/optimal-edge-discovery.feature
@@ -1,5 +1,5 @@
   @Optimal_Edge_Discovery
-Feature: CAMARA Optimal Edge Discovery API, v0.1.0 - Operations for discovering optimal edge cloud zones
+Feature: CAMARA Optimal Edge Discovery API, vwip - Operations for discovering optimal edge cloud zones
 
 # Input to be provided by the implementation to the tests
 #
@@ -10,7 +10,7 @@ Feature: CAMARA Optimal Edge Discovery API, v0.1.0 - Operations for discovering 
 
   Background: Common Optimal Edge Discovery setup
     Given an environment at "apiRoot"
-    And the resource "/optimal-edge-discovery/v0.1.0"
+    And the resource "/optimal-edge-discovery/vwip"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Adds a planning-oriented Optimal Edge Discovery operation:

`POST /retrieve-viable-edge-cloud-zones`

The new operation lets API consumers evaluate which edge cloud zones are viable candidates for one or more target areas and an application profile before deployment, without requiring an active device or user session.

The API contract intentionally keeps the response at the public planning-abstraction level. It does not expose UPF, DNN, S-NSSAI, routing policy, topology, or other operator-internal details, and estimated metrics are documented as planning indicators rather than runtime guarantees.

This branch was prepared from the `r1.2` tag.

Main additions:

- `retrieveViableEdgeCloudZones` operation
- `PreDeploymentEdgeDiscoveryInfo` request schema
- `PreDeploymentEdgeDiscoveryResponse` response schema
- `EdgeCloudZoneViability` candidate result schema
- target area, edge cloud zone criteria, network operator criteria, pricing tier, and latency estimate schemas
- request and response examples
- reusable `EdgeCloudZoneStatus` schema extracted from the existing inline status definition

Example request:

```json
{
  "targetAreas": [
    { "areaId": "patras" },
    { "areaId": "athens" }
  ],
  "applicationProfileId": "2fa85f64-5717-4562-b3fc-2c963f66afa0",
  "edgeCloudZoneCriteria": {
    "edgeCloudRegion": "gr-west-1",
    "edgeCloudProviders": ["EdgeCo Neutral Host"]
  },
  "networkOperatorCriteria": {
    "pricingTiers": ["STANDARD", "PREMIUM"]
  },
  "maxResults": 4,
  "includeNonViableCandidates": false
}
```

Example response excerpt:

```json
{
  "applicationProfileId": "2fa85f64-5717-4562-b3fc-2c963f66afa0",
  "validUntil": "2026-05-19T12:15:00Z",
  "areaResults": [
    {
      "targetArea": { "areaId": "patras" },
      "edgeCloudZoneViabilities": [
        {
          "edgeCloudZone": {
            "edgeCloudZoneId": "4f7b5555-6457-4890-9d4e-1dc79f44ab66",
            "edgeCloudZoneName": "GR West Zone A",
            "edgeCloudProvider": "EdgeCo Neutral Host",
            "edgeCloudRegion": "gr-west-1",
            "edgeCloudZoneStatus": "active"
          },
          "viability": "VIABLE",
          "networkOperatorCommercialInfo": {
            "pricingTiers": ["PREMIUM"]
          },
          "estimatedMetrics": {
            "latencyEstimate": {
              "p50LatencyMs": 8,
              "p95LatencyMs": 14
            }
          }
        }
      ]
    }
  ]
}
```

#### Which issue(s) this PR fixes:

Issue #35 

#### Special notes for reviewers:

The repository does not currently include a local CAMARA Commonalities schema file, so `Area` is included as a local placeholder with a TODO to replace it with the Commonalities `Area` schema once imported.

#### Changelog input

```
release-note
Added pre-deployment edge cloud zone viability discovery operation for planning viable edge cloud zone candidates by target area and application profile.
```

#### Additional documentation 

This PR updates the OpenAPI definition inline with operation and schema descriptions.

```
docs
OpenAPI examples added for the new pre-deployment viability operation.
```
